### PR TITLE
feature : handle windows resize event for shaded region

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ src/*.d.ts
 src/*/*.d.ts
 src/*/*/*.d.ts
 docs/
+output/

--- a/src/camera/core-impl.ts
+++ b/src/camera/core-impl.ts
@@ -164,6 +164,7 @@ class RenderedCameraImpl implements RenderedCamera {
         videoElement.style.display = "block";
         videoElement.muted = true;
         videoElement.setAttribute("muted", "true");
+        videoElement.id = 'qr-reader-video';
         (<any>videoElement).playsInline = true;
         return videoElement;
     }

--- a/src/html5-qrcode.ts
+++ b/src/html5-qrcode.ts
@@ -603,6 +603,35 @@ export class Html5Qrcode {
             return Promise.resolve();
         });
     }
+    
+    /**
+     * Restart streaming QR Code video and scanning.
+     *
+     * @returns Promise for safely closing the video stream.
+     */
+    public restart(
+        cameraIdOrConfig: string | MediaTrackConstraints,
+        configuration: Html5QrcodeCameraScanConfig | undefined,
+        qrCodeSuccessCallback: QrcodeSuccessCallback | undefined,
+        qrCodeErrorCallback: QrcodeErrorCallback | undefined,
+    ): Promise<void> {
+        return this.stop()
+        .then(() => {
+            // stopped now start again
+            return Promise.resolve(
+                this.start (
+                    cameraIdOrConfig,
+                    configuration,
+                    qrCodeSuccessCallback,
+                    qrCodeErrorCallback
+                )
+            );
+        })
+        .catch((err: any) => {
+        // Stop failed, handle it.
+        return Promise.reject(err);
+    });;
+    }
     //#endregion
 
     //#region File scan related public APIs
@@ -1614,6 +1643,7 @@ export class Html5Qrcode {
             this.element.removeChild(childElement);
         }
      };
+    
     private handleOrientationChange(viewfinderWidth: number, viewfinderHeight: number, configuration: Html5QrcodeCameraScanConfig) {
         let $this = this;
         $this.removeQrRegion();


### PR DESCRIPTION
I was working with a client who needed a QR code scanner for all mobile and tablet devices. The requirements included opening the camera in a 100vw viewport with a 16:9 aspect ratio and supporting window resizing.

In the original library, I encountered an issue with resizing. Upon window resize, the shaded region was getting distorted, which affected the visual consistency of the scanner. It looked something like this.
##Portrait
![html5-qrcode-portrait-mode](https://github.com/user-attachments/assets/3e726ac8-0bbd-4239-bf22-224cdd405aeb)
##Landscape
![html5-qrcode-landscape-mode](https://github.com/user-attachments/assets/eab03121-7d29-44a4-b984-c22f7db3b97a)

For the that project, I handled it this way
`window.addEventListener('resize', () => {restartScanning()})`
`function restartScanning(){
stopScanning().then(() => {startScanning()});
}`

I have now decided to include this feature directly in the library. Therefore, I am adding an event listener (`resize`) in the start function to handle window resizing. However, instead of restarting the camera, I am managing the resize dynamically.

- Remove the QR shaded region if it exists.
- Resize the video element to the new client width.
- Repaint the QR shaded region if enabled.

This approach is working smoothly
Thanks
